### PR TITLE
Updated travis URL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 Go Tokens Library
 =================
 
-.. image:: https://travis-ci.org/zalando/go-tokens.svg?branch=master
-    :target: https://travis-ci.org/zalando/go-tokens
+.. image:: https://travis-ci.org/zalando-incubator/go-tokens.svg?branch=master
+    :target: https://travis-ci.org/zalando-incubator/go-tokens
 
 .. image:: https://codecov.io/github/zalando/go-tokens/coverage.svg?branch=master
     :target: https://codecov.io/github/zalando/go-tokens?branch=master


### PR DESCRIPTION
The badge was still using the previous URL